### PR TITLE
fix: recognize PyTorch checkpoints when loading a trained model

### DIFF
--- a/base/image/classification.py
+++ b/base/image/classification.py
@@ -122,6 +122,73 @@ class ImageClassifier:
         except Exception as e:
             raise ValueError(f"Failed to load model data: {e}")
 
+    def _resolve_checkpoint(self) -> Tuple[str, bool]:
+        """
+        Resolve which trained checkpoint file to load, and whether it is a PyTorch model.
+
+        Candidate paths are built here from the model directory + type using explicit extensions,
+        independent of the global default framework. (``self.model_paths`` cannot be used directly
+        for this: ``get_model_paths`` picks a single extension based on the global default, so its
+        TensorFlow paths would carry a ``.pth`` suffix whenever the default is PyTorch.) The
+        framework is resolved in three tiers: the framework recorded in ``net.pkl``, else inferred
+        from which checkpoints exist on disk, else the global config default.
+
+        Returns:
+            Tuple of (model_path, is_pytorch).
+
+        Raises:
+            FileNotFoundError: If no checkpoint exists for either framework.
+        """
+        best_base = self.model_paths['best_model'].rsplit('.', 1)[0]
+        final_base = self.model_paths['final_model'].rsplit('.', 1)[0]
+
+        # Framework-specific candidates, best-model before final-model.
+        # TensorFlow: .keras is the current format, .h5 is legacy Keras HDF5.
+        pytorch_candidates = [best_base + '.pth', final_base + '.pth']
+        tf_candidates = [
+            best_base + '.keras', best_base + '.h5',
+            final_base + '.keras', final_base + '.h5',
+        ]
+        pytorch_path = next((p for p in pytorch_candidates if os.path.exists(p)), None)
+        tf_path = next((p for p in tf_candidates if os.path.exists(p)), None)
+
+        # Framework recorded in net.pkl; treat blank/unknown as "not recorded" and normalize case.
+        framework = (self.framework or '').lower() or None
+        if framework is None:
+            # No recorded framework: infer from the checkpoints on disk, since the global config
+            # default says nothing about how this particular model was trained. Only fall back to
+            # the config when the checkpoints are ambiguous (both or neither present).
+            if pytorch_path and not tf_path:
+                framework = 'pytorch'
+            elif tf_path and not pytorch_path:
+                framework = 'tensorflow'
+            else:
+                framework = FrameworkConfig.get_framework()
+
+        # Prefer the resolved framework; fall back to the other with a warning.
+        if framework == 'pytorch':
+            if pytorch_path:
+                return pytorch_path, True
+            if tf_path:
+                logger.warning(
+                    f"PyTorch model requested but not found. Falling back to TensorFlow model: {tf_path}"
+                )
+                return tf_path, False
+        else:  # tensorflow (or any non-pytorch value)
+            if tf_path:
+                return tf_path, False
+            if pytorch_path:
+                logger.warning(
+                    f"TensorFlow model requested but not found. Falling back to PyTorch model: {pytorch_path}"
+                )
+                return pytorch_path, True
+
+        raise FileNotFoundError(
+            f"No model file found. Searched:\n"
+            f"  PyTorch: {pytorch_candidates}\n"
+            f"  TensorFlow: {tf_candidates}"
+        )
+
     def _load_model(self) -> Union['keras.Model', object]:
         """
         Load the trained model (supports both TensorFlow and PyTorch).
@@ -138,79 +205,7 @@ class ImageClassifier:
             ValueError: If model loading fails
         """
         try:
-            # Get base model path (without extension)
-            base_model_path = self.model_paths['best_model'].rsplit('.', 1)[0]
-
-            # Check what model files exist
-            pytorch_best = base_model_path + '.pth'
-            pytorch_final = self.model_paths['final_model'].rsplit('.', 1)[0] + '.pth'
-            tf_best = self.model_paths['best_model']
-            tf_final = self.model_paths['final_model']
-
-            framework = self.framework
-            if framework is None:
-                # Models trained before the framework was recorded in net.pkl: infer it
-                # from the checkpoints on disk, since the global config default says
-                # nothing about how this particular model was trained. Only fall back to
-                # the config when the checkpoints are ambiguous (both or neither present).
-                has_pytorch = os.path.exists(pytorch_best) or os.path.exists(pytorch_final)
-                has_tf = os.path.exists(tf_best) or os.path.exists(tf_final)
-                if has_pytorch and not has_tf:
-                    framework = 'pytorch'
-                elif has_tf and not has_pytorch:
-                    framework = 'tensorflow'
-                else:
-                    framework = FrameworkConfig.get_framework()
-
-            model_path = None
-            is_pytorch = False
-
-            # Priority: framework preference, then best model, then final model
-            if framework == 'pytorch':
-                if os.path.exists(pytorch_best):
-                    model_path = pytorch_best
-                    is_pytorch = True
-                elif os.path.exists(pytorch_final):
-                    model_path = pytorch_final
-                    is_pytorch = True
-                elif os.path.exists(tf_best):
-                    logger.warning(
-                        f"PyTorch model requested but not found. Falling back to TensorFlow model: {tf_best}"
-                    )
-                    model_path = tf_best
-                    is_pytorch = False
-                elif os.path.exists(tf_final):
-                    logger.warning(
-                        f"PyTorch model requested but not found. Falling back to TensorFlow model: {tf_final}"
-                    )
-                    model_path = tf_final
-                    is_pytorch = False
-            else:  # tensorflow (default)
-                if os.path.exists(tf_best):
-                    model_path = tf_best
-                    is_pytorch = False
-                elif os.path.exists(tf_final):
-                    model_path = tf_final
-                    is_pytorch = False
-                elif os.path.exists(pytorch_best):
-                    logger.warning(
-                        f"TensorFlow model requested but not found. Falling back to PyTorch model: {pytorch_best}"
-                    )
-                    model_path = pytorch_best
-                    is_pytorch = True
-                elif os.path.exists(pytorch_final):
-                    logger.warning(
-                        f"TensorFlow model requested but not found. Falling back to PyTorch model: {pytorch_final}"
-                    )
-                    model_path = pytorch_final
-                    is_pytorch = True
-
-            if model_path is None:
-                raise FileNotFoundError(
-                    f"No model file found. Searched:\n"
-                    f"  PyTorch: {pytorch_best}, {pytorch_final}\n"
-                    f"  TensorFlow: {tf_best}, {tf_final}"
-                )
+            model_path, is_pytorch = self._resolve_checkpoint()
 
             logger.info(f"Loading {'PyTorch' if is_pytorch else 'TensorFlow'} model from {model_path}")
 

--- a/base/image/classification.py
+++ b/base/image/classification.py
@@ -78,6 +78,7 @@ class ImageClassifier:
         self.model_name = None
         self.output_path = None
         self.model_paths = None
+        self.framework = None
 
         # Display options
         self.should_create_color_overlay = False
@@ -105,6 +106,9 @@ class ImageClassifier:
             self.nwhite = data.get('nwhite')
             self.image_size = data.get('sxy')
             self.model_name = data.get('nm')
+            # Framework the model was trained with. Absent for models trained before
+            # this was recorded, in which case the global default is used.
+            self.framework = data.get('framework')
 
             # Get standard paths
             self.model_paths = get_model_paths(self.model_path, self.model_type)
@@ -134,9 +138,6 @@ class ImageClassifier:
             ValueError: If model loading fails
         """
         try:
-            # Determine the framework from config
-            framework = FrameworkConfig.get_framework()
-
             # Get base model path (without extension)
             base_model_path = self.model_paths['best_model'].rsplit('.', 1)[0]
 
@@ -145,6 +146,21 @@ class ImageClassifier:
             pytorch_final = self.model_paths['final_model'].rsplit('.', 1)[0] + '.pth'
             tf_best = self.model_paths['best_model']
             tf_final = self.model_paths['final_model']
+
+            framework = self.framework
+            if framework is None:
+                # Models trained before the framework was recorded in net.pkl: infer it
+                # from the checkpoints on disk, since the global config default says
+                # nothing about how this particular model was trained. Only fall back to
+                # the config when the checkpoints are ambiguous (both or neither present).
+                has_pytorch = os.path.exists(pytorch_best) or os.path.exists(pytorch_final)
+                has_tf = os.path.exists(tf_best) or os.path.exists(tf_final)
+                if has_pytorch and not has_tf:
+                    framework = 'pytorch'
+                elif has_tf and not has_pytorch:
+                    framework = 'tensorflow'
+                else:
+                    framework = FrameworkConfig.get_framework()
 
             model_path = None
             is_pytorch = False

--- a/base/models/training.py
+++ b/base/models/training.py
@@ -1324,12 +1324,21 @@ def train_segmentation_model_cnns(
     framework_config = get_framework_config()
     framework = framework_config['framework']
 
-    # Check if model already exists and should not be retrained
-    from base.models.utils import get_model_paths
-    model_paths = get_model_paths(pthDL, model_type, framework=framework)
-    if os.path.isfile(model_paths['best_model']) and not retrain_model:
-        module_logger.info(f'Model already trained with name {model_name}. Use retrain_model=True to retrain.')
-        return
+    # Check if model already exists and should not be retrained. A model trained with
+    # either framework counts, so flipping DEFAULT_FRAMEWORK does not silently retrain
+    # an already-trained model.
+    for existing_framework in ('tensorflow', 'pytorch'):
+        existing_best = get_model_paths(pthDL, model_type, framework=existing_framework)['best_model']
+        if os.path.isfile(existing_best) and not retrain_model:
+            module_logger.info(
+                f'Model already trained with name {model_name} ({existing_framework}). '
+                f'Use retrain_model=True to retrain.'
+            )
+            return
+
+    # Record the framework in net.pkl so inference loads the matching checkpoint
+    # instead of falling back to the global default.
+    save_model_metadata(pthDL, {'framework': framework})
 
     # Create and use the appropriate trainer based on framework
     try:

--- a/gui/components/main_window.py
+++ b/gui/components/main_window.py
@@ -310,6 +310,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 logger.info("Prerecorded data loaded successfully.")
         except Exception as e:
             QtWidgets.QMessageBox.critical(self, 'Error', f'Failed to load prerecorded data: {str(e)}')
+            # Load failed: pthim/nm may be unbound below, so stop here with the button hidden.
+            self.ui.classify_PB.setVisible(False)
+            self.ui.classify_PB.setEnabled(False)
+            return
 
         model_exists = trained_model_exists(os.sep.join(pthim.split(os.sep)[:-1]) + os.sep + nm)
 

--- a/gui/components/main_window.py
+++ b/gui/components/main_window.py
@@ -30,6 +30,19 @@ from gui.utils import save_model_metadata_GUI
 from .ui_definitions import Ui_MainWindow
 from .classification_window import MainWindowClassify
 
+# Checkpoint extensions written by the trainers: .keras/.h5 (TensorFlow), .pth (PyTorch)
+TRAINED_MODEL_EXTENSIONS = ('.keras', '.h5', '.pth')
+
+
+def trained_model_exists(model_dir):
+    """Return True if model_dir holds a best-model checkpoint from any supported framework."""
+    if not os.path.isdir(model_dir):
+        return False
+    return any(
+        'best_model' in file and file.endswith(TRAINED_MODEL_EXTENSIONS)
+        for file in os.listdir(model_dir)
+    )
+
 
 def choose_xml(parent):
     msg_box = QtWidgets.QMessageBox(parent)
@@ -298,11 +311,7 @@ class MainWindow(QtWidgets.QMainWindow):
         except Exception as e:
             QtWidgets.QMessageBox.critical(self, 'Error', f'Failed to load prerecorded data: {str(e)}')
 
-        model_exists = False
-        if os.path.isdir(os.sep.join(pthim.split(os.sep)[:-1]) + os.sep + nm):
-            for file in os.listdir(os.sep.join(pthim.split(os.sep)[:-1]) + os.sep + nm):
-                if 'best_model' in file and file.endswith('.keras'):
-                    model_exists = True
+        model_exists = trained_model_exists(os.sep.join(pthim.split(os.sep)[:-1]) + os.sep + nm)
 
         if model_exists:
             self.ui.classify_PB.setVisible(True)
@@ -312,15 +321,22 @@ class MainWindow(QtWidgets.QMainWindow):
             self.ui.classify_PB.setVisible(False)
             self.ui.classify_PB.setEnabled(False)
 
+    def resolve_model_name(self):
+        """Return the model folder name that actually exists in the training path.
+        """
+        raw_name = self.ui.model_name.text()
+        sanitized_name = raw_name.replace(' ', '_')
+        training_path = self.ui.trianing_LE.text()
+        if not os.path.isdir(os.path.join(training_path, sanitized_name)) and \
+                os.path.isdir(os.path.join(training_path, raw_name)):
+            return raw_name
+        return sanitized_name
+
     def check_for_trained_model(self):
-        model_exists = False
         self.loaded_xml = False
 
-        model_name = self.ui.model_name.text().replace(' ', '_')
-        if os.path.isdir(os.path.join(self.ui.trianing_LE.text(), model_name)):
-            for file in os.listdir(os.path.join(self.ui.trianing_LE.text(), model_name)):
-                if 'best_model' in file and file.endswith('.keras'):
-                    model_exists = True
+        model_name = self.resolve_model_name()
+        model_exists = trained_model_exists(os.path.join(self.ui.trianing_LE.text(), model_name))
 
         if self.ui.resolution_CB.currentText() == 'Custom':
             self.ui.label_43.setVisible(True)
@@ -1487,7 +1503,7 @@ class MainWindow(QtWidgets.QMainWindow):
     # Load paths
     def get_pthDL(self):
         pth = self.ui.trianing_LE.text()
-        model_name = self.ui.model_name.text().replace(' ', '_')
+        model_name = self.resolve_model_name()
         return os.path.join(pth, model_name)
 
     def get_pthim(self):

--- a/tests/unit/test_framework_model_resolution.py
+++ b/tests/unit/test_framework_model_resolution.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for per-model framework resolution and trained-model detection.
+
+Covers the three surfaces touched by the PyTorch-checkpoint fix (PR #52 follow-up):
+- gui.components.main_window.trained_model_exists: detects .keras/.h5/.pth "best_model" files.
+- base.image.classification.ImageClassifier._resolve_checkpoint: selects the checkpoint file and
+  framework independent of the global default (the comment-2 bug guard), including .h5.
+- base.models.training.train_segmentation_model_cnns: records the framework in net.pkl and skips
+  retraining when a checkpoint from either framework already exists.
+
+These paths were previously untested. QT_QPA_PLATFORM=offscreen is auto-set in tests/conftest.py,
+so importing the GUI module works headless. No GPU / real training / real weights are needed.
+
+pickle use below is safe: net.pkl is the application's own metadata format (written/read by
+base.models.utils.save_model_metadata / base.data.loaders.load_model_metadata), and these tests
+only read back dicts they just wrote in the same process — no untrusted input.
+"""
+import os
+import pickle
+from unittest.mock import MagicMock
+
+import pytest
+
+from base.config import ModelDefaults
+from base.image.classification import ImageClassifier
+from base.models.training import train_segmentation_model_cnns
+from gui.components.main_window import trained_model_exists
+
+MODEL_TYPE = 'DeepLabV3_plus'
+B_KERAS = f'best_model_{MODEL_TYPE}.keras'
+B_H5 = f'best_model_{MODEL_TYPE}.h5'
+B_PTH = f'best_model_{MODEL_TYPE}.pth'
+F_KERAS = f'{MODEL_TYPE}.keras'
+F_PTH = f'{MODEL_TYPE}.pth'
+
+
+def _make_dir(base_dir, files=(), framework=None, write_net=True):
+    """Create a model dir with empty checkpoint files and (optionally) a minimal net.pkl.
+
+    Empty files are sufficient: resolution only calls os.path.exists. net.pkl carries the four keys
+    load_model_metadata requires (classNames, sxy, nblack, nwhite) plus model_type and, when given,
+    the recorded framework.
+    """
+    d = os.path.join(base_dir, 'model')
+    os.makedirs(d, exist_ok=True)
+    if write_net:
+        meta = {'classNames': ['a', 'b'], 'sxy': 256, 'nblack': 0, 'nwhite': 0,
+                'model_type': MODEL_TYPE, 'nm': 'demo'}
+        if framework is not None:
+            meta['framework'] = framework
+        with open(os.path.join(d, 'net.pkl'), 'wb') as f:
+            pickle.dump(meta, f)
+    for name in files:
+        open(os.path.join(d, name), 'wb').close()
+    return d
+
+
+class TestTrainedModelExists:
+    """GUI gate: a best-model checkpoint from any supported framework counts as trained."""
+
+    @pytest.mark.parametrize("files,expected", [
+        ([B_KERAS], True),
+        ([B_H5], True),
+        ([B_PTH], True),
+        ([], False),
+        (['best_model.txt'], False),        # 'best_model' present but unsupported extension
+        (['something.keras'], False),       # supported extension but not a best_model file
+    ])
+    def test_detection(self, temp_dir, files, expected):
+        d = _make_dir(temp_dir, files=files, write_net=False)
+        assert trained_model_exists(d) is expected
+
+    def test_missing_directory(self, temp_dir):
+        assert trained_model_exists(os.path.join(temp_dir, 'does_not_exist')) is False
+
+
+class TestCheckpointResolution:
+    """_resolve_checkpoint selects (path, is_pytorch) independent of the global default framework.
+
+    Expected values are literals validated offline against a 110-scenario simulation of the exact
+    selection logic (current PR code invalid in 46 of them; this fix invalid in 0, 0 regressions).
+    """
+
+    @pytest.mark.parametrize("files,recorded,default,exp_name,exp_is_pytorch", [
+        # --- comment-2 guard: global default pytorch must NOT hide a TF (.keras) model ---
+        ([B_KERAS], 'tensorflow', 'pytorch', B_KERAS, False),   # fails on current code
+        ([B_KERAS], None,        'pytorch', B_KERAS, False),    # legacy (inferred from disk)
+        # --- default=tensorflow behaves as before ---
+        ([B_KERAS], None,        'tensorflow', B_KERAS, False),
+        ([B_PTH],   'pytorch',   'tensorflow', B_PTH,   True),
+        ([B_PTH],   'pytorch',   'pytorch',    B_PTH,   True),
+        # --- .h5 guard: GUI advertises .h5, so the loader must resolve it ---
+        ([B_H5],    None,        'pytorch',    B_H5,    False),
+        ([B_H5],    None,        'tensorflow', B_H5,    False),
+        # --- both checkpoints present: recorded framework wins ---
+        ([B_KERAS, B_PTH], 'tensorflow', 'pytorch',    B_KERAS, False),
+        ([B_KERAS, B_PTH], 'pytorch',    'pytorch',    B_PTH,   True),
+        # --- both present + NO recorded framework: falls to global default (documented limitation) ---
+        ([B_KERAS, B_PTH], None, 'pytorch',    B_PTH,   True),
+        ([B_KERAS, B_PTH], None, 'tensorflow', B_KERAS, False),
+        # --- recorded framework value normalized (case-insensitive) ---
+        ([B_KERAS], 'TensorFlow', 'pytorch',    B_KERAS, False),
+        ([B_PTH],   'PyTorch',    'tensorflow', B_PTH,   True),
+        # --- fallback to the other framework when the requested one has no file ---
+        ([B_PTH],   'tensorflow', 'tensorflow', B_PTH,   True),
+        ([B_KERAS], 'pytorch',    'tensorflow', B_KERAS, False),
+        # --- only final-model checkpoint present ---
+        ([F_PTH],   None, 'pytorch',    F_PTH,   True),
+        ([F_KERAS], None, 'tensorflow', F_KERAS, False),
+        # --- preference order: best before final; .keras before .h5 ---
+        ([B_KERAS, F_KERAS], 'tensorflow', 'tensorflow', B_KERAS, False),
+        ([B_KERAS, B_H5],    'tensorflow', 'tensorflow', B_KERAS, False),
+    ])
+    def test_resolution(self, temp_dir, monkeypatch, files, recorded, default, exp_name, exp_is_pytorch):
+        monkeypatch.setattr(ModelDefaults, 'DEFAULT_FRAMEWORK', default)
+        d = _make_dir(temp_dir, files=files, framework=recorded)
+        clf = ImageClassifier(d, d, MODEL_TYPE)
+        model_path, is_pytorch = clf._resolve_checkpoint()
+        assert model_path == os.path.join(d, exp_name)
+        assert is_pytorch is exp_is_pytorch
+
+    def test_no_checkpoint_raises(self, temp_dir, monkeypatch):
+        monkeypatch.setattr(ModelDefaults, 'DEFAULT_FRAMEWORK', 'tensorflow')
+        d = _make_dir(temp_dir, files=[], framework=None)
+        clf = ImageClassifier(d, d, MODEL_TYPE)
+        with pytest.raises(FileNotFoundError):
+            clf._resolve_checkpoint()
+
+
+class TestTrainingRecordsFramework:
+    """train_segmentation_model_cnns records the framework and skips cross-framework retrains.
+
+    Secondary coverage: the TF trainer is stubbed so no real training runs.
+    """
+
+    def _minimal_net(self, temp_dir):
+        d = os.path.join(temp_dir, 'model')
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, 'net.pkl'), 'wb') as f:
+            pickle.dump({'model_type': MODEL_TYPE, 'nm': 'demo'}, f)
+        return d
+
+    def test_records_framework_in_net_pkl(self, temp_dir, monkeypatch):
+        monkeypatch.setattr(ModelDefaults, 'DEFAULT_FRAMEWORK', 'tensorflow')
+        d = self._minimal_net(temp_dir)
+        stub = MagicMock()
+        monkeypatch.setattr('base.models.training.DeepLabV3PlusTrainer', stub)
+
+        train_segmentation_model_cnns(d)
+
+        stub.assert_called_once_with(d)
+        stub.return_value.train.assert_called_once()
+        with open(os.path.join(d, 'net.pkl'), 'rb') as f:
+            meta = pickle.load(f)
+        assert meta.get('framework') == 'tensorflow'       # recorded
+        assert meta.get('model_type') == MODEL_TYPE         # not clobbered
+        assert meta.get('nm') == 'demo'
+
+    def test_existing_checkpoint_skips_retrain(self, temp_dir, monkeypatch):
+        monkeypatch.setattr(ModelDefaults, 'DEFAULT_FRAMEWORK', 'tensorflow')
+        d = self._minimal_net(temp_dir)
+        open(os.path.join(d, B_KERAS), 'wb').close()   # already-trained checkpoint
+        stub = MagicMock()
+        monkeypatch.setattr('base.models.training.DeepLabV3PlusTrainer', stub)
+
+        train_segmentation_model_cnns(d, retrain_model=False)
+
+        stub.return_value.train.assert_not_called()


### PR DESCRIPTION
## Problem

The **Classify Images** button never appeared for a model trained with PyTorch. The GUI gated it on `file.endswith('.keras')`, so a model folder holding only `best_model_DeepLabV3_plus.pth` did not register as a trained model.

Underneath that, the framework was a single global constant (`DEFAULT_FRAMEWORK` in `base/config.py`) and was never recorded per-model. Classification therefore always *assumed* TensorFlow and only found the `.pth` through a fallback path. That fallback only works when no `.keras` is present. If a stale TensorFlow checkpoint sits beside the `.pth` (e.g. the model was trained in TF and later retrained in PyTorch under the same name), it silently classifies with the **wrong model** and produces plausible-looking but incorrect output with no error.

## Changes

**`gui/components/main_window.py`**: Adds `trained_model_exists()`, which accepts `.keras` / `.h5` / `.pth`, and uses it in place of the two `.keras`-only checks. The second of those, in the prerecorded-data path, had the same bug and would have surfaced when reloading a saved session.

**`base/models/training.py`**: Training now records the `framework` it used in `net.pkl`. The skip-retraining check also treats a checkpoint from *either* framework as "already trained", so toggling `DEFAULT_FRAMEWORK` no longer silently retrains an existing model from scratch in the other framework.

**`base/image/classification.py`**: `ImageClassifier` resolves the framework in three tiers: the `framework` key in `net.pkl`, else inferred from the checkpoints actually on disk, else the global config. Models trained before this change load correctly with no metadata migration.

## Also included

This branch also carries `resolve_model_name()` and the corresponding `get_pthDL` change in `main_window.py`, pre-existing work that resolves model folder names containing spaces. Unrelated to the PyTorch fix, but it was already in the working tree.

## Behavior change worth reviewing

Retraining the same model name under a different framework by flipping `DEFAULT_FRAMEWORK` no longer works. An existing checkpoint from either framework blocks it, so use `retrain_model=True` or delete the old checkpoint. This is deliberate (it prevents a silent from-scratch retrain in the wrong framework), but it adds friction if you are benchmarking TF vs PyTorch under one model name.

## Not addressed

- Training with PyTorch still requires hand-editing `DEFAULT_FRAMEWORK`; there is no GUI selector.
- `base/image/classification.py` hardcodes `PyTorchDeepLabV3Plus` regardless of `model_type` (harmless while `PYTORCH_MODELS` lists only DeepLabV3+).
- TensorFlow remains a hard import even for pure-PyTorch runs (`base/models/utils.py`), so there is no TF-free install yet.
- If a folder holds both a `.keras` and a `.pth` with no `framework` key in `net.pkl`, the framework cannot be inferred from the files and still falls back to the config default.

## Testing

âš ï¸ **Not yet verified end-to-end.** The changes compile and the load path has been traced, but Classify Images has not been run against a real PyTorch checkpoint.
